### PR TITLE
permute op may have more than 4 dims

### DIFF
--- a/Caffe/layer_param.py
+++ b/Caffe/layer_param.py
@@ -93,7 +93,7 @@ class Layer_param():
         self.param.norm_param.CopyFrom(l2norm_param)
 
 
-    def permute_param(self, order1, order2, order3, order4):
+    def permute_param(self, order):
         """
         add a conv_param layer if you spec the layer type "Convolution"
         Args:
@@ -105,7 +105,7 @@ class Layer_param():
         Returns:
         """
         permute_param = pb.PermuteParameter()
-        permute_param.order.extend([order1, order2, order3, order4])
+        permute_param.order.extend(*order)
 
         self.param.permute_param.CopyFrom(permute_param)
 

--- a/pytorch_to_caffe.py
+++ b/pytorch_to_caffe.py
@@ -607,12 +607,8 @@ def _permute(input, *args):
     log.add_blobs([x], name='permute_blob')
     layer = caffe_net.Layer_param(name=name, type='Permute',
                                   bottom=[log.blobs(input)], top=[log.blobs(x)])
-    order1 = args[0]
-    order2 = args[1]
-    order3 = args[2]
-    order4 = args[3]
 
-    layer.permute_param(order1, order2, order3, order4)
+    layer.permute_param(*args)
     log.cnet.add_layer(layer)
     return x
 


### PR DESCRIPTION
for example last layers of SSD need to permute tensor of 4 dims, but yolov5 need to permute tensor is 5. master version must be 4 dim tensor, may occur convert error.